### PR TITLE
added 8bit image encodings, image scaling on resize is now 1:1 with rviz

### DIFF
--- a/src/utils/processing.js
+++ b/src/utils/processing.js
@@ -140,3 +140,25 @@ export const imageDataToCanvas = imageData => {
   context.putImageData(imageData, 0, 0);
   return canvas;
 };
+
+export const populateImageDataFromImageMsg = (
+  message,
+  offset,
+  rgbaOrder,
+  imageData,
+) => {
+  const { data: rawData, height, step } = message;
+  const typedArray = Uint8Array.from(rawData);
+  // endianness is required for > 8bit encodings
+  const encodedDataView = new DataView(typedArray.buffer);
+
+  let j = 0;
+  for (let i = 0; i < step * height; i += offset) {
+    for (let k = 0; k < rgbaOrder.length; k++) {
+      imageData.data[j++] = encodedDataView.getUint8(i + rgbaOrder[k]);
+    }
+    if (rgbaOrder.length === 3) {
+      imageData.data[j++] = 255;
+    }
+  }
+};


### PR DESCRIPTION
Goal is to have 1:1 correspondence with Rviz + other formats over that.

*Rviz image types: http://wiki.ros.org/rviz/DisplayTypes/Image*

RGB8 - implemented 
RGBA8 - implemented
BGR8 - implemented
BGRA8 - implemented
MONO8 - implemented
MONO16 - NOT IMPLEMENTED (can't figure out how to generate this one)
BAYER_BGGR8 - implemented
BAYER_GBRG8 - implemented
BAYER_GRBG8 - implemented
BAYER_GRBG8 - implemented


for these 4 formats, rviz treats them as mono8 encoding, which appears to be incorrect to me (maybe it should be mono16 as it is 16UC1 type). for now we are keeping these as the same as in rviz, but later should investigate more and perhaps implement demosiac step to colorize the image. (https://github.com/codeplaysoftware/visioncpp/wiki/Example:-Bayer-Filter-Demosaic) (http://www.imagemagick.org/discourse-server/viewtopic.php?t=29459).
BAYER_RGGB16 - implemented
BAYER_BGGR16 - implemented
BAYER_GBRG16 - implemented
BAYER_GRBG16 - implemented


8UC4 - implemented
8SC4 - implemented
8UC3 - implemented
8SC3 - implemented
8UC1 - implmented
8SC1 - implemented

the following formats have not been implemented yet, but these are not supported in rviz either, implementation is *easy* but need to figure out a way to generate the 16/32bit images that has these encodings (will be doing this along with the tutorial for publishing images in the coming week). moreover, the data from these images must be normalized first (https://github.com/ros-visualization/rviz/blob/melodic-devel/src/rviz/image/ros_image_texture.cpp#L236)
16UC1, 16SC1, 32FC1 

*Other encodings supported by ROS but not by rviz: http://docs.ros.org/jade/api/sensor_msgs/html/image__encodings_8h_source.html*
Same status as the above paragraph
