### PR TITLE
WIP - added experimental support for pointcloud decoding with wasm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3888,8 +3888,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3910,14 +3909,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3932,20 +3929,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4062,8 +4056,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4075,7 +4068,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4090,7 +4082,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4098,14 +4089,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4124,7 +4113,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4205,8 +4193,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4218,7 +4205,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4304,8 +4290,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4341,7 +4326,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4361,7 +4345,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4405,14 +4388,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ import Scene from './core/scene';
 import Viewer2d from './viewers/2d';
 import Viewer3d from './viewers/3d';
 import TfViewer from './viewers/Tf';
+import { PCLDecoder } from './utils/pcl';
 
 export default {
   CollisionObject,
@@ -46,4 +47,6 @@ export default {
   Viewer2d,
   Viewer3d,
   TfViewer,
+
+  PCLDecoder,
 };

--- a/src/utils/pcl.js
+++ b/src/utils/pcl.js
@@ -1,5 +1,9 @@
 import * as THREE from 'three';
-import { MAX_POINTCLOUD_POINTS, POINT_FIELD_DATATYPES } from './constants';
+import {
+  MAX_POINTCLOUD_POINTS,
+  POINT_FIELD_DATATYPES,
+  POINTCLOUD_COLOR_CHANNELS,
+} from './constants';
 
 export const getAccessorForDataType = (dataView, dataType) => {
   switch (dataType) {
@@ -45,3 +49,140 @@ export const setOrUpdateGeometryAttribute = (geometry, attribute, data) => {
   }
   geometry.attributes[attribute].needsUpdate = true;
 };
+
+let pclDecoderModule;
+export class PCLDecoder {
+  static decode(message, colorChannel, useRainbow) {
+    const n = message.height * message.width;
+    const positions = new Float32Array(3 * n);
+    const colors = new Float32Array(3 * n);
+    const normals = new Float32Array(3 * n);
+
+    const uint8Buffer = Uint8Array.from(message.data).buffer;
+    const dataView = new DataView(uint8Buffer);
+    const offsets = {};
+    const accessor = {};
+
+    message.fields.forEach(f => {
+      offsets[f.name] = f.offset;
+      accessor[f.name] = getAccessorForDataType(dataView, message.datatype);
+    });
+
+    for (let i = 0; i < n; i++) {
+      const stride = i * message.point_step;
+      if (
+        offsets.x !== undefined &&
+        offsets.y !== undefined &&
+        offsets.z !== undefined
+      ) {
+        positions[3 * i] = accessor.x.call(
+          dataView,
+          stride + offsets.x,
+          !message.big_endian,
+        );
+        positions[3 * i + 1] = accessor.y.call(
+          dataView,
+          stride + offsets.y,
+          !message.big_endian,
+        );
+        positions[3 * i + 2] = accessor.z.call(
+          dataView,
+          stride + offsets.z,
+          !message.big_endian,
+        );
+      }
+
+      if (
+        offsets.rgb !== undefined &&
+        colorChannel === POINTCLOUD_COLOR_CHANNELS.RGB
+      ) {
+        colors[3 * i] = dataView.getUint8(stride + offsets.rgb + 2) / 255.0;
+        colors[3 * i + 1] = dataView.getUint8(stride + offsets.rgb + 1) / 255.0;
+        colors[3 * i + 2] = dataView.getUint8(stride + offsets.rgb) / 255.0;
+      }
+
+      if (
+        offsets.intensity !== undefined &&
+        colorChannel === POINTCLOUD_COLOR_CHANNELS.INTENSITY
+      ) {
+        const intensity = accessor.intensity.call(
+          dataView,
+          stride + offsets.intensity,
+          !message.big_endian,
+        );
+        colors[3 * i] = useRainbow ? 0 : Math.min(intensity / 255, 255);
+        colors[3 * i + 1] = Math.min(intensity / 255, 255);
+        colors[3 * i + 2] = useRainbow ? 0 : Math.min(intensity / 255, 255);
+      }
+
+      if (
+        offsets.normal_x !== undefined &&
+        offsets.normal_y !== undefined &&
+        offsets.normal_z !== undefined
+      ) {
+        normals[3 * i] = accessor.normal_x.call(
+          dataView,
+          stride + offsets.normal_x,
+          !message.big_endian,
+        );
+        normals[3 * i + 1] = accessor.normal_y.call(
+          dataView,
+          stride + offsets.normal_y,
+          !message.big_endian,
+        );
+        normals[3 * i + 2] = accessor.normal_z.call(
+          dataView,
+          stride + offsets.normal_z,
+          !message.big_endian,
+        );
+      }
+    }
+    return { positions, colors, normals };
+  }
+
+  static attachDecoder(module) {
+    const { memory, PCLDecoder: PCLDecoderWasm } = module;
+    pclDecoderModule = PCLDecoderWasm.new();
+
+    const wasmDecode = (message, colorChannel, useRainbow) => {
+      const n = message.height * message.width;
+      const offsets = {};
+      const normals = new Float32Array(3 * n);
+
+      message.fields.forEach(f => {
+        offsets[f.name] = f.offset;
+      });
+
+      const memoryTypedArray = new Uint8Array(memory.buffer);
+      const copyMemPtr = pclDecoderModule.get_copy_memory_ptr();
+      memoryTypedArray.set(message.data, copyMemPtr);
+      pclDecoderModule.compute(
+        n,
+        message.point_step,
+        offsets.x,
+        offsets.y,
+        offsets.z,
+        offsets.rgb || 0,
+        offsets.intensity || 0,
+        colorChannel === POINTCLOUD_COLOR_CHANNELS.INTENSITY,
+        useRainbow,
+      );
+      const positionMemPointer = pclDecoderModule.get_position_memory_ptr();
+      const colorMemPointer = pclDecoderModule.get_color_memory_ptr();
+      const positions = new Float32Array(
+        module.memory.buffer,
+        positionMemPointer,
+        3 * n,
+      );
+      const colors = new Float32Array(
+        module.memory.buffer,
+        colorMemPointer,
+        3 * n,
+      );
+
+      return { positions, colors, normals };
+    };
+
+    PCLDecoder.decode = wasmDecode;
+  }
+}

--- a/src/viz/PointCloud.js
+++ b/src/viz/PointCloud.js
@@ -5,12 +5,8 @@ import {
   DEFAULT_OPTIONS_POINTCLOUD,
   MAX_POINTCLOUD_POINTS,
   MESSAGE_TYPE_POINTCLOUD2,
-  POINTCLOUD_COLOR_CHANNELS,
 } from '../utils/constants';
-import {
-  getAccessorForDataType,
-  setOrUpdateGeometryAttribute,
-} from '../utils/pcl';
+import { PCLDecoder, setOrUpdateGeometryAttribute } from '../utils/pcl';
 
 const editPointCloudPoints = function(message, options) {
   if (!message) {
@@ -23,90 +19,11 @@ const editPointCloudPoints = function(message, options) {
 
   const { colorChannel, useRainbow } = options;
 
-  const n = message.height * message.width;
-  const positions = new Float32Array(3 * n);
-  const colors = new Float32Array(3 * n);
-  const normals = new Float32Array(3 * n);
-
-  const uint8Buffer = Uint8Array.from(message.data).buffer;
-  const dataView = new DataView(uint8Buffer);
-  const offsets = {};
-  const accessor = {};
-
-  message.fields.forEach(f => {
-    offsets[f.name] = f.offset;
-    accessor[f.name] = getAccessorForDataType(dataView, message.datatype);
-  });
-
-  for (let i = 0; i < n; i++) {
-    const stride = i * message.point_step;
-    if (
-      offsets.x !== undefined &&
-      offsets.y !== undefined &&
-      offsets.z !== undefined
-    ) {
-      positions[3 * i] = accessor.x.call(
-        dataView,
-        stride + offsets.x,
-        !message.big_endian,
-      );
-      positions[3 * i + 1] = accessor.y.call(
-        dataView,
-        stride + offsets.y,
-        !message.big_endian,
-      );
-      positions[3 * i + 2] = accessor.z.call(
-        dataView,
-        stride + offsets.z,
-        !message.big_endian,
-      );
-    }
-
-    if (
-      offsets.rgb !== undefined &&
-      colorChannel === POINTCLOUD_COLOR_CHANNELS.RGB
-    ) {
-      colors[3 * i] = dataView.getUint8(stride + offsets.rgb + 2) / 255.0;
-      colors[3 * i + 1] = dataView.getUint8(stride + offsets.rgb + 1) / 255.0;
-      colors[3 * i + 2] = dataView.getUint8(stride + offsets.rgb) / 255.0;
-    }
-
-    if (
-      offsets.intensity !== undefined &&
-      colorChannel === POINTCLOUD_COLOR_CHANNELS.INTENSITY
-    ) {
-      const intensity = accessor.intensity.call(
-        dataView,
-        stride + offsets.intensity,
-        !message.big_endian,
-      );
-      colors[3 * i] = useRainbow ? 0 : Math.min(intensity / 255, 255);
-      colors[3 * i + 1] = Math.min(intensity / 255, 255);
-      colors[3 * i + 2] = useRainbow ? 0 : Math.min(intensity / 255, 255);
-    }
-
-    if (
-      offsets.normal_x !== undefined &&
-      offsets.normal_y !== undefined &&
-      offsets.normal_z !== undefined
-    ) {
-      normals[3 * i] = accessor.normal_x.call(
-        dataView,
-        stride + offsets.normal_x,
-        !message.big_endian,
-      );
-      normals[3 * i + 1] = accessor.normal_y.call(
-        dataView,
-        stride + offsets.normal_y,
-        !message.big_endian,
-      );
-      normals[3 * i + 2] = accessor.normal_z.call(
-        dataView,
-        stride + offsets.normal_z,
-        !message.big_endian,
-      );
-    }
-  }
+  const { colors, normals, positions } = PCLDecoder.decode(
+    message,
+    colorChannel,
+    useRainbow,
+  );
 
   return {
     positions,


### PR DESCRIPTION
DO NOT MERGE - Experimental

This PR adds support for an additional PCL decoder that is supplied by the consumer through:

```
Amphion.PCLDecoder.attachDecoder(module);
```

Roughly 10-15% perf boost can be expected on pointclouds currently.

The reasons for keeping the decoder outside of Amphion are:

1. Chrome does not allow instantiating > 4KB wasm module on the main thread. To enable a direct import in Amphion, we first have to add web-workers support. It is really difficult (if not impossible) to keep the module size so small with `wasm-bindgen` being a must.

2. The default webpack loader does have support for `Webassembly.instantiateStreaming`, but it depends upon the server providing the proper mime-type of `application/wasm` for the file. We cannot depend upon the client to do this, and this crashes Amphion in that case.

3. Even with `1`, and `2` solved, this could be a good way to enable a plugin system in Amphion. If the above is not configured, Amphion uses the default implementation.

Other problems:

1. The default webpack loader does not allow the user to add configs for initial and maximum allowed memory at the moment. This is alright for very small pointclouds (< 4000 points), but larger pointclouds need a larger pre-allocated memory. Wasm memory can be increased dynamically (which invalidates the current one, so its a tricky operation (wasm-bindgen helps with this)), but only upto the allowed maximum. This requires changes to the webpack loader, or a custom loader altogether.

2. It is possible to possible to use a `static mut` declaration for the memory holding arrays in rust, which does allow us to render large pointclouds, but that increases the wasm module size to 40+ MB  for ~500_000 points. I tested this and we get ~10% perf boost. It is not really a solution.

3. ROSLibJS deserializes the message to a `UInt8Array` on the JS heap. Wasm cannot currently read JS memory directly (other way around works), so we have to copy the memory from JS to the wasm linear memory for computation (`TypedArray.set` works). This whole pipeline is pretty expensive and costs us perf + 2 times the required memory. Not sure how to take care of this (forking ROSLibJS sounds like a bad idea already).

Going forward, we have the following checklist (in order of importance IMO):

- [ ] eject from cra in zethus (done, this is required to add the webpack loader) and remove all the useless parts to allow easier package/config upgrades (optional)
- [ ] a better webpack loader for wasm that supports config (or add support to current webpack loader)
- [ ] add support for web-workers to Amphion (optional, but helps in keeping the application smooth, and lets us use multi-threading)
- [ ] minor improvements to memory management and check for memory leaks
- [ ] improvements to the `pcl-decoder` package and open-sourcing it

![screenshot](https://i.imgur.com/P1PSuuO.png)