### PR TITLE
release/v0.1.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@
 
 ### Fixed
 
+## [0.1.14] - 2019-10-22
+### Added
+- Interactive Markers
+- Text view-facing markers
+
+
+### Removed
+
+### Changed
+- Upgrade Three.js and eslint
+- Change from window.onresize to using resize observer for viewers
+- Markers now support lifetime
+
+### Fixed
+- Husky now works only on staged files (lint-staged)
+
+## [0.1.13] - 2019-09-18
+### Added
+- Wrench
+- Range
+
+### Fixed
+- 2D viewer camera rotate
+
+## [0.1.12] - 2019-08-27
+### Changed
+- Updated Three.js and eslint config
+- Updated eslint-utils
+
+### Fixed
+- Handle is_diff in robot scene attached collision objects for planning
+
+## [0.1.11] - 2019-08-22
+### Added
+- Pointcloud color, intensity channels
+- Pointcloud performance optimizations
+- Support more image encodings
+- Planning scene trajectory collision
+
+### Changed
+- Axis of scene is now z-axis
+
+### Fixed
+- Pointcloud rendering
+
+
 ## [0.1.13] - 2019-09-18
 ### Added
 - Wrench

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,6 @@
 - Interactive Markers
 - Text view-facing markers
 
-
-### Removed
-
 ### Changed
 - Upgrade Three.js and eslint
 - Change from window.onresize to using resize observer for viewers
@@ -22,36 +19,6 @@
 
 ### Fixed
 - Husky now works only on staged files (lint-staged)
-
-## [0.1.13] - 2019-09-18
-### Added
-- Wrench
-- Range
-
-### Fixed
-- 2D viewer camera rotate
-
-## [0.1.12] - 2019-08-27
-### Changed
-- Updated Three.js and eslint config
-- Updated eslint-utils
-
-### Fixed
-- Handle is_diff in robot scene attached collision objects for planning
-
-## [0.1.11] - 2019-08-22
-### Added
-- Pointcloud color, intensity channels
-- Pointcloud performance optimizations
-- Support more image encodings
-- Planning scene trajectory collision
-
-### Changed
-- Axis of scene is now z-axis
-
-### Fixed
-- Pointcloud rendering
-
 
 ## [0.1.13] - 2019-09-18
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amphion",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "roslibjs based web visualization library",
   "main": "./src/index.js",
   "repository": {


### PR DESCRIPTION
## [0.1.14] - 2019-10-22
### Added
- Interactive Markers
- Text view-facing markers

### Changed
- Upgrade Three.js and eslint
- Change from window.onresize to using resize observer for viewers
- Markers now support lifetime

### Fixed
- Husky now works only on staged files (lint-staged)