### PR TITLE
add pcl-decoder wasm module

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,7 @@
     "worker": true
   },
   "parserOptions": {
-    "ecmaVersion": 2018,
+    "ecmaVersion": 2020,
     "sourceType": "module"
   },
   "rules": {
@@ -34,6 +34,7 @@
     "no-undef": "warn",
     "no-case-declarations": "off",
     "array-callback-return": "off",
-    "camelcase": "warn"
+    "camelcase": "warn",
+    "allowImportExportEverywhere": 0
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amphion",
-  "version": "0.1.20",
+  "version": "0.1.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4944,11 +4944,6 @@
         "readable-stream": "^2.0.1",
         "wbuf": "^1.1.0"
       }
-    },
-    "hsl-to-rgb-for-reals": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/hsl-to-rgb-for-reals/-/hsl-to-rgb-for-reals-1.1.1.tgz",
-      "integrity": "sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg=="
     },
     "html-entities": {
       "version": "1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amphion",
-  "version": "0.1.18",
+  "version": "0.1.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1086,9 +1086,9 @@
       "dev": true
     },
     "acorn-jsx": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
-      "integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
+      "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
       "dev": true
     },
     "after": {
@@ -1161,6 +1161,23 @@
       "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
+      },
+      "dependencies": {
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        }
       }
     },
     "any-observable": {
@@ -2128,21 +2145,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "requires": {
-        "color-name": "1.1.3"
-      }
-    },
-    "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
     "commander": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
@@ -3008,9 +3010,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.2.2.tgz",
-      "integrity": "sha512-mf0elOkxHbdyGX1IJEUsNBzCDdyoUgljF3rRlgfyYh0pwGnreLc0jjD6ZuleOibjmnUWZLY2eXwSooeOgGJ2jw==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.6.0.tgz",
+      "integrity": "sha512-PpEBq7b6qY/qrOmpYQ/jTMDYfuQMELR4g4WI1M/NaSDDD/bdcMb+dj4Hgks7p41kW2caXsPsEZAEAyAgjVVC0g==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -3020,9 +3022,9 @@
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
         "eslint-scope": "^5.0.0",
-        "eslint-utils": "^1.4.2",
+        "eslint-utils": "^1.4.3",
         "eslint-visitor-keys": "^1.1.0",
-        "espree": "^6.1.1",
+        "espree": "^6.1.2",
         "esquery": "^1.0.1",
         "esutils": "^2.0.2",
         "file-entry-cache": "^5.0.1",
@@ -3032,7 +3034,7 @@
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^6.4.1",
+        "inquirer": "^7.0.0",
         "is-glob": "^4.0.0",
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
@@ -3069,9 +3071,9 @@
           }
         },
         "glob-parent": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
-          "integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+          "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
           "dev": true,
           "requires": {
             "is-glob": "^4.0.1"
@@ -3339,12 +3341,12 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
-      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
       "dev": true,
       "requires": {
-        "eslint-visitor-keys": "^1.0.0"
+        "eslint-visitor-keys": "^1.1.0"
       }
     },
     "eslint-visitor-keys": {
@@ -3354,20 +3356,20 @@
       "dev": true
     },
     "espree": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
-      "integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
+      "integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
       "dev": true,
       "requires": {
-        "acorn": "^7.0.0",
-        "acorn-jsx": "^5.0.2",
+        "acorn": "^7.1.0",
+        "acorn-jsx": "^5.1.0",
         "eslint-visitor-keys": "^1.1.0"
       },
       "dependencies": {
         "acorn": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.0.0.tgz",
-          "integrity": "sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+          "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
           "dev": true
         }
       }
@@ -4943,6 +4945,11 @@
         "wbuf": "^1.1.0"
       }
     },
+    "hsl-to-rgb-for-reals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hsl-to-rgb-for-reals/-/hsl-to-rgb-for-reals-1.1.1.tgz",
+      "integrity": "sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg=="
+    },
     "html-entities": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
@@ -5344,31 +5351,112 @@
       "dev": true
     },
     "inquirer": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
-      "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.0.tgz",
+      "integrity": "sha512-rSdC7zelHdRQFkWnhsMu2+2SO41mpv2oF2zy4tMhmiLWkcKbOAs87fWAJhVXttKVwhdZvymvnuM95EyEXg2/tQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.2.0",
+        "ansi-escapes": "^4.2.1",
         "chalk": "^2.4.2",
-        "cli-cursor": "^2.1.0",
+        "cli-cursor": "^3.1.0",
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.3",
-        "figures": "^2.0.0",
-        "lodash": "^4.17.12",
-        "mute-stream": "0.0.7",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.15",
+        "mute-stream": "0.0.8",
         "run-async": "^2.2.0",
         "rxjs": "^6.4.0",
-        "string-width": "^2.1.0",
+        "string-width": "^4.1.0",
         "strip-ansi": "^5.1.0",
         "through": "^2.3.6"
       },
       "dependencies": {
+        "ansi-escapes": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
+          "integrity": "sha512-Cg3ymMAdN10wOk/VYfLV7KCQyv7EDirJ64500sU7n9UlmioEtDuU5Gd+hj73hXSU/ex7tHJSssmyftDdkMLO8Q==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.5.2"
+          }
+        },
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
+        },
+        "cli-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^3.1.0"
+          }
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "figures": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
+          "integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
+        },
+        "onetime": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+          "dev": true,
+          "requires": {
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "string-width": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz",
+          "integrity": "sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^5.2.0"
+          }
         },
         "strip-ansi": {
           "version": "5.2.0",
@@ -5378,6 +5466,12 @@
           "requires": {
             "ansi-regex": "^4.1.0"
           }
+        },
+        "type-fest": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
+          "integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==",
+          "dev": true
         }
       }
     },
@@ -6589,9 +6683,9 @@
       "dev": true
     },
     "mute-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
     "nan": {
@@ -7261,6 +7355,11 @@
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
       }
+    },
+    "pcl-decoder": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/pcl-decoder/-/pcl-decoder-0.1.7.tgz",
+      "integrity": "sha512-hdRKcfsf+oHnGl0Gb4Fj7167x/K03Hd64/kaDMSYMCoPxhc6lUZ8mw9V2dQldb3HNLNG0OY2/8+CBjWOQOVXeQ=="
     },
     "picomatch": {
       "version": "2.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amphion",
-  "version": "0.1.20",
+  "version": "0.1.19",
   "description": "roslibjs based web visualization library",
   "main": "./build/amphion.js",
   "repository": {
@@ -21,7 +21,6 @@
   },
   "dependencies": {
     "@juggle/resize-observer": "^2.2.1",
-    "hsl-to-rgb-for-reals": "^1.1.1",
     "lodash.debounce": "^4.0.8",
     "pcl-decoder": "^0.1.7",
     "randomcolor": "^0.5.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amphion",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "roslibjs based web visualization library",
   "main": "./build/amphion.js",
   "repository": {
@@ -21,7 +21,9 @@
   },
   "dependencies": {
     "@juggle/resize-observer": "^2.2.1",
+    "hsl-to-rgb-for-reals": "^1.1.1",
     "lodash.debounce": "^4.0.8",
+    "pcl-decoder": "^0.1.7",
     "randomcolor": "^0.5.4",
     "roslib": "^1.0.1",
     "stats-js": "^1.0.1",
@@ -43,7 +45,7 @@
     "@babel/plugin-transform-runtime": "^7.6.2",
     "@babel/preset-env": "^7.5.4",
     "babel-loader": "^8.0.6",
-    "eslint": "^6.2.2",
+    "eslint": "^6.6.0",
     "eslint-config-airbnb": "^18.0.1",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-config-prettier": "^6.0.0",

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -346,7 +346,7 @@ export const DEFAULT_OPTIONS_POINTCLOUD = {
   compression: 'cbor',
   colorChannel: POINTCLOUD_COLOR_CHANNELS.RGB,
   size: 0.0125,
-  useRainbow: false,
+  useRainbow: true,
 };
 
 export const DEFAULT_OPTIONS_POINT = {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -347,6 +347,7 @@ export const DEFAULT_OPTIONS_POINTCLOUD = {
   colorChannel: POINTCLOUD_COLOR_CHANNELS.RGB,
   size: 0.0125,
   useRainbow: true,
+  queueSize: 1,
 };
 
 export const DEFAULT_OPTIONS_POINT = {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -6,7 +6,7 @@ export const OBJECT_TYPE_ARROW_WITH_CIRCLE = 'ArrowWithCircle';
 export const OBJECT_TYPE_AXES = 'Axes';
 export const OBJECT_TYPE_FLAT_ARROW = 'FlatArrow';
 
-export const MAX_POINTCLOUD_POINTS = 500000;
+export const MAX_POINTCLOUD_POINTS = 5000000;
 
 export const DEFAULT_BACKGROUND_COLOR = '#000000';
 export const DEFAULT_GRID_SIZE = 30;

--- a/src/utils/pcl.js
+++ b/src/utils/pcl.js
@@ -36,18 +36,13 @@ export const getAccessorForDataType = (dataView, dataType) => {
   }
 };
 
-export const setOrUpdateGeometryAttribute = (geometry, attribute, data) => {
-  if (geometry.attributes[attribute] === undefined) {
-    geometry.addAttribute(
-      attribute,
-      new THREE.BufferAttribute(
-        new Float32Array(data, 0, MAX_POINTCLOUD_POINTS * 3),
-        3,
-      ).setDynamic(true),
-    );
-  } else {
-    geometry.attributes[attribute].array = data;
-  }
+export const updateGeometryAttribute = (geometry, attribute, data, l) => {
+  geometry.attributes[attribute].updateRange = {
+    offset: 0,
+    count: l * 3,
+  };
+  geometry.attributes[attribute].count = l;
+  geometry.attributes[attribute].array = data;
   geometry.attributes[attribute].needsUpdate = true;
 };
 

--- a/src/utils/pcl.js
+++ b/src/utils/pcl.js
@@ -187,7 +187,13 @@ export class PCLDecoder {
         positionMemPointer,
         3 * n,
       );
-      const colors = new Float32Array(memory.buffer, colorMemPointer, 3 * n);
+      const invalidChannel =
+        (colorChannel === POINTCLOUD_COLOR_CHANNELS.INTENSITY &&
+          !offsets.intensity) ||
+        (colorChannel === POINTCLOUD_COLOR_CHANNELS.RGB && !offsets.rgb);
+      const colors = invalidChannel
+        ? new Float32Array(3 * n)
+        : new Float32Array(memory.buffer, colorMemPointer, 3 * n);
       return { positions, colors, normals };
     };
   }

--- a/src/utils/pcl.js
+++ b/src/utils/pcl.js
@@ -1,5 +1,10 @@
 import * as THREE from 'three';
-import { MAX_POINTCLOUD_POINTS, POINT_FIELD_DATATYPES } from './constants';
+import convertColor from 'hsl-to-rgb-for-reals';
+import {
+  MAX_POINTCLOUD_POINTS,
+  POINT_FIELD_DATATYPES,
+  POINTCLOUD_COLOR_CHANNELS,
+} from './constants';
 
 export const getAccessorForDataType = (dataView, dataType) => {
   switch (dataType) {
@@ -45,3 +50,151 @@ export const setOrUpdateGeometryAttribute = (geometry, attribute, data) => {
   }
   geometry.attributes[attribute].needsUpdate = true;
 };
+
+export class PCLDecoder {
+  static decode(message, colorChannel, useRainbow) {
+    const n = message.height * message.width;
+    const positions = new Float32Array(3 * n);
+    const colors = new Float32Array(3 * n);
+    const normals = new Float32Array(3 * n);
+
+    const uint8Buffer = Uint8Array.from(message.data).buffer;
+    const dataView = new DataView(uint8Buffer);
+    const offsets = {};
+    const accessor = {};
+
+    message.fields.forEach(f => {
+      offsets[f.name] = f.offset;
+      accessor[f.name] = getAccessorForDataType(dataView, message.datatype);
+    });
+
+    for (let i = 0; i < n; i++) {
+      const stride = i * message.point_step;
+      if (
+        offsets.x !== undefined &&
+        offsets.y !== undefined &&
+        offsets.z !== undefined
+      ) {
+        positions[3 * i] = accessor.x.call(
+          dataView,
+          stride + offsets.x,
+          !message.is_bigendian,
+        );
+        positions[3 * i + 1] = accessor.y.call(
+          dataView,
+          stride + offsets.y,
+          !message.is_bigendian,
+        );
+        positions[3 * i + 2] = accessor.z.call(
+          dataView,
+          stride + offsets.z,
+          !message.is_bigendian,
+        );
+      }
+
+      if (
+        offsets.rgb !== undefined &&
+        colorChannel === POINTCLOUD_COLOR_CHANNELS.RGB
+      ) {
+        colors[3 * i] = dataView.getUint8(stride + offsets.rgb + 2) / 255.0;
+        colors[3 * i + 1] = dataView.getUint8(stride + offsets.rgb + 1) / 255.0;
+        colors[3 * i + 2] = dataView.getUint8(stride + offsets.rgb) / 255.0;
+      }
+
+      if (
+        offsets.intensity !== undefined &&
+        colorChannel === POINTCLOUD_COLOR_CHANNELS.INTENSITY
+      ) {
+        const intensity = accessor.intensity.call(
+          dataView,
+          stride + offsets.intensity,
+          !message.is_bigendian,
+        );
+
+        const normalizedIntensity = Math.min(intensity, 360);
+
+        if (useRainbow) {
+          const rgb = convertColor(normalizedIntensity, 1.0, 0.5);
+          colors[3 * i] = rgb[0] / 255;
+          colors[3 * i + 1] = rgb[1] / 255;
+          colors[3 * i + 2] = rgb[2] / 255;
+        } else {
+          colors[3 * i] = normalizedIntensity / 360;
+          colors[3 * i + 1] = normalizedIntensity / 360;
+          colors[3 * i + 2] = normalizedIntensity / 360;
+        }
+      }
+
+      if (
+        offsets.normal_x !== undefined &&
+        offsets.normal_y !== undefined &&
+        offsets.normal_z !== undefined
+      ) {
+        normals[3 * i] = accessor.normal_x.call(
+          dataView,
+          stride + offsets.normal_x,
+          !message.is_bigendian,
+        );
+        normals[3 * i + 1] = accessor.normal_y.call(
+          dataView,
+          stride + offsets.normal_y,
+          !message.is_bigendian,
+        );
+        normals[3 * i + 2] = accessor.normal_z.call(
+          dataView,
+          stride + offsets.normal_z,
+          !message.is_bigendian,
+        );
+      }
+    }
+    return { positions, colors, normals };
+  }
+
+  static attachDecoder(module) {
+    const { get_memory: getMemory, PCLDecoder: PCLDecoderWasm } = module;
+    const pclDecoderModule = new PCLDecoderWasm();
+    const memory = getMemory();
+
+    PCLDecoder.decode = (message, colorChannel, useRainbow) => {
+      const n = message.height * message.width;
+      const offsets = {};
+      const normals = new Float32Array(3 * n);
+
+      message.fields.forEach(f => {
+        offsets[f.name] = f.offset;
+      });
+
+      const memoryTypedArray = new Uint8Array(memory.buffer);
+
+      const copyMemPtr = pclDecoderModule.get_copy_memory_ptr();
+
+      memoryTypedArray.set(message.data, copyMemPtr);
+      pclDecoderModule.compute(
+        n,
+        message.point_step,
+        offsets.x,
+        offsets.y,
+        offsets.z,
+        offsets.rgb || 0,
+        offsets.intensity || 0,
+        colorChannel === POINTCLOUD_COLOR_CHANNELS.INTENSITY,
+        useRainbow,
+      );
+      const positionMemPointer = pclDecoderModule.get_position_memory_ptr();
+      const colorMemPointer = pclDecoderModule.get_color_memory_ptr();
+      const positions = new Float32Array(
+        memory.buffer,
+        positionMemPointer,
+        3 * n,
+      );
+      const colors = new Float32Array(memory.buffer, colorMemPointer, 3 * n);
+      return { positions, colors, normals };
+    };
+  }
+}
+
+if (typeof WebAssembly !== 'undefined') {
+  import('pcl-decoder').then(module => {
+    PCLDecoder.attachDecoder(module);
+  });
+}

--- a/src/viz/PointCloud.js
+++ b/src/viz/PointCloud.js
@@ -5,12 +5,8 @@ import {
   DEFAULT_OPTIONS_POINTCLOUD,
   MAX_POINTCLOUD_POINTS,
   MESSAGE_TYPE_POINTCLOUD2,
-  POINTCLOUD_COLOR_CHANNELS,
 } from '../utils/constants';
-import {
-  getAccessorForDataType,
-  setOrUpdateGeometryAttribute,
-} from '../utils/pcl';
+import { PCLDecoder, setOrUpdateGeometryAttribute } from '../utils/pcl';
 
 const editPointCloudPoints = function(message, options) {
   if (!message) {
@@ -23,90 +19,11 @@ const editPointCloudPoints = function(message, options) {
 
   const { colorChannel, useRainbow } = options;
 
-  const n = message.height * message.width;
-  const positions = new Float32Array(3 * n);
-  const colors = new Float32Array(3 * n);
-  const normals = new Float32Array(3 * n);
-
-  const uint8Buffer = Uint8Array.from(message.data).buffer;
-  const dataView = new DataView(uint8Buffer);
-  const offsets = {};
-  const accessor = {};
-
-  message.fields.forEach(f => {
-    offsets[f.name] = f.offset;
-    accessor[f.name] = getAccessorForDataType(dataView, message.datatype);
-  });
-
-  for (let i = 0; i < n; i++) {
-    const stride = i * message.point_step;
-    if (
-      offsets.x !== undefined &&
-      offsets.y !== undefined &&
-      offsets.z !== undefined
-    ) {
-      positions[3 * i] = accessor.x.call(
-        dataView,
-        stride + offsets.x,
-        !message.big_endian,
-      );
-      positions[3 * i + 1] = accessor.y.call(
-        dataView,
-        stride + offsets.y,
-        !message.big_endian,
-      );
-      positions[3 * i + 2] = accessor.z.call(
-        dataView,
-        stride + offsets.z,
-        !message.big_endian,
-      );
-    }
-
-    if (
-      offsets.rgb !== undefined &&
-      colorChannel === POINTCLOUD_COLOR_CHANNELS.RGB
-    ) {
-      colors[3 * i] = dataView.getUint8(stride + offsets.rgb + 2) / 255.0;
-      colors[3 * i + 1] = dataView.getUint8(stride + offsets.rgb + 1) / 255.0;
-      colors[3 * i + 2] = dataView.getUint8(stride + offsets.rgb) / 255.0;
-    }
-
-    if (
-      offsets.intensity !== undefined &&
-      colorChannel === POINTCLOUD_COLOR_CHANNELS.INTENSITY
-    ) {
-      const intensity = accessor.intensity.call(
-        dataView,
-        stride + offsets.intensity,
-        !message.big_endian,
-      );
-      colors[3 * i] = useRainbow ? 0 : Math.min(intensity / 255, 255);
-      colors[3 * i + 1] = Math.min(intensity / 255, 255);
-      colors[3 * i + 2] = useRainbow ? 0 : Math.min(intensity / 255, 255);
-    }
-
-    if (
-      offsets.normal_x !== undefined &&
-      offsets.normal_y !== undefined &&
-      offsets.normal_z !== undefined
-    ) {
-      normals[3 * i] = accessor.normal_x.call(
-        dataView,
-        stride + offsets.normal_x,
-        !message.big_endian,
-      );
-      normals[3 * i + 1] = accessor.normal_y.call(
-        dataView,
-        stride + offsets.normal_y,
-        !message.big_endian,
-      );
-      normals[3 * i + 2] = accessor.normal_z.call(
-        dataView,
-        stride + offsets.normal_z,
-        !message.big_endian,
-      );
-    }
-  }
+  const { colors, normals, positions } = PCLDecoder.decode(
+    message,
+    colorChannel,
+    useRainbow,
+  );
 
   return {
     positions,

--- a/src/viz/PointCloud.js
+++ b/src/viz/PointCloud.js
@@ -6,7 +6,7 @@ import {
   MAX_POINTCLOUD_POINTS,
   MESSAGE_TYPE_POINTCLOUD2,
 } from '../utils/constants';
-import { PCLDecoder, setOrUpdateGeometryAttribute } from '../utils/pcl';
+import { PCLDecoder, updateGeometryAttribute } from '../utils/pcl';
 
 const editPointCloudPoints = function(message, options) {
   if (!message) {
@@ -43,6 +43,27 @@ class PointCloud extends Core {
       vertexColors: THREE.VertexColors,
     });
     const geometry = new THREE.BufferGeometry();
+    geometry.addAttribute(
+      'position',
+      new THREE.BufferAttribute(
+        new Float32Array(MAX_POINTCLOUD_POINTS * 3),
+        3,
+      ).setDynamic(true),
+    );
+    geometry.addAttribute(
+      'color',
+      new THREE.BufferAttribute(
+        new Float32Array(MAX_POINTCLOUD_POINTS * 3),
+        3,
+      ).setDynamic(true),
+    );
+    geometry.addAttribute(
+      'normal',
+      new THREE.BufferAttribute(
+        new Float32Array(MAX_POINTCLOUD_POINTS * 3),
+        3,
+      ).setDynamic(true),
+    );
     geometry.setDrawRange(0, 0);
     geometry.computeBoundingSphere();
     this.object = new THREE.Points(geometry, cloudMaterial);
@@ -55,8 +76,6 @@ class PointCloud extends Core {
 
   updatePointCloudGeometry(positions, colors, normals) {
     const { geometry, material } = this.object;
-    // TODO: investigate the next line
-    geometry.dispose();
     if (
       material.size !== this.options.size &&
       !Number.isNaN(this.options.size)
@@ -64,11 +83,11 @@ class PointCloud extends Core {
       material.size = this.options.size;
       material.needsUpdate = true;
     }
-    const l = Math.min(MAX_POINTCLOUD_POINTS, positions.length);
+    const l = Math.min(MAX_POINTCLOUD_POINTS, Math.floor(positions.length / 3));
     geometry.setDrawRange(0, l);
-    setOrUpdateGeometryAttribute(geometry, 'position', positions);
-    setOrUpdateGeometryAttribute(geometry, 'color', colors);
-    setOrUpdateGeometryAttribute(geometry, 'normal', normals);
+    updateGeometryAttribute(geometry, 'position', positions, l);
+    updateGeometryAttribute(geometry, 'color', colors, l);
+    updateGeometryAttribute(geometry, 'normal', normals, l);
   }
 
   update(message) {

--- a/src/viz/PointCloud.js
+++ b/src/viz/PointCloud.js
@@ -55,6 +55,8 @@ class PointCloud extends Core {
 
   updatePointCloudGeometry(positions, colors, normals) {
     const { geometry, material } = this.object;
+    // TODO: investigate the next line
+    geometry.dispose();
     if (
       material.size !== this.options.size &&
       !Number.isNaN(this.options.size)


### PR DESCRIPTION
Adds wasm support for pointclouds in Amphion. Solves all issues from the previous PR.

Requires a client that can serve `wasm` files with correct mime-types (latest webpack does that but CRA does not).

DO NOT MERGE until the corresponding Zethus PR is merged.