### PR TITLE
interactive marker handle colors now match the rviz colors

### DIFF
--- a/src/utils/interactiveMarkerManager.js
+++ b/src/utils/interactiveMarkerManager.js
@@ -155,37 +155,6 @@ export default class InteractiveMarkerManager {
     }
   }
 
-  static getAlignment(rotation) {
-    const threshold = 10 ** -3;
-    const [x, y, z] = rotation.toArray();
-    for (let i = -4; i <= 4; i++) {
-      const angle = (i * Math.PI) / 2;
-      if (
-        Math.abs(x - angle) < threshold &&
-        Math.abs(y) < threshold &&
-        Math.abs(z) < threshold
-      ) {
-        return 'x';
-      }
-      if (
-        Math.abs(y - angle) < threshold &&
-        Math.abs(x) < threshold &&
-        Math.abs(z) < threshold
-      ) {
-        return 'y';
-      }
-      if (
-        Math.abs(z - angle) < threshold &&
-        Math.abs(y) < threshold &&
-        Math.abs(x) < threshold
-      ) {
-        return 'z';
-      }
-    }
-
-    return null;
-  }
-
   static enableControls(
     object,
     interactionMode,
@@ -202,25 +171,9 @@ export default class InteractiveMarkerManager {
     const controlsManagerRotation = new THREE.Euler().setFromQuaternion(
       controlsManagerOrientation,
     );
-    const alignment = InteractiveMarkerManager.getAlignment(
+    const alignmentColor = InteractiveMarkerManager.getAlignmentColor(
       controlsManagerRotation,
     );
-    let alignmentColor;
-    switch (alignment) {
-      case 'x': {
-        alignmentColor = 'red';
-        break;
-      }
-      case 'y': {
-        alignmentColor = 'green';
-        break;
-      }
-      case 'z': {
-        alignmentColor = 'blue';
-        break;
-      }
-      default:
-    }
     const color = alignmentColor || givenColor;
 
     // currently only ROTATE_AXIS is supported for VIEW_FACING mode
@@ -337,6 +290,37 @@ export default class InteractiveMarkerManager {
       object.userData.handlesControlsMap[handle] = controlName;
     });
     controlsManager.showByNames(handles, true);
+  }
+
+  static getAlignmentColor(rotation) {
+    const threshold = 10 ** -3;
+    const [x, y, z] = rotation.toArray();
+    for (let i = -4; i <= 4; i++) {
+      const angle = (i * Math.PI) / 2;
+      if (
+        Math.abs(x - angle) < threshold &&
+        Math.abs(y) < threshold &&
+        Math.abs(z) < threshold
+      ) {
+        return 'red';
+      }
+      if (
+        Math.abs(y - angle) < threshold &&
+        Math.abs(x) < threshold &&
+        Math.abs(z) < threshold
+      ) {
+        return 'green';
+      }
+      if (
+        Math.abs(z - angle) < threshold &&
+        Math.abs(y) < threshold &&
+        Math.abs(x) < threshold
+      ) {
+        return 'blue';
+      }
+    }
+
+    return null;
   }
 
   removeObject(id) {

--- a/src/utils/interactiveMarkerManager.js
+++ b/src/utils/interactiveMarkerManager.js
@@ -2,7 +2,7 @@ import {
   ANCHOR_MODE,
   DEFAULT_HANDLE_GROUP_NAME,
 } from 'three-freeform-controls';
-import * as THREE from 'three';
+import { Quaternion, Euler } from 'three';
 import randomColor from 'randomcolor';
 import Group from '../primitives/Group';
 import MarkerManager from './markerManager';
@@ -166,9 +166,9 @@ export default class InteractiveMarkerManager {
   ) {
     controlsManager.showAll(false);
 
-    const controlsManagerOrientation = new THREE.Quaternion();
+    const controlsManagerOrientation = new Quaternion();
     controlsManager.getWorldQuaternion(controlsManagerOrientation);
-    const controlsManagerRotation = new THREE.Euler().setFromQuaternion(
+    const controlsManagerRotation = new Euler().setFromQuaternion(
       controlsManagerOrientation,
     );
     const alignmentColor = InteractiveMarkerManager.getAlignmentColor(

--- a/src/utils/interactiveMarkerManager.js
+++ b/src/utils/interactiveMarkerManager.js
@@ -2,6 +2,7 @@ import {
   ANCHOR_MODE,
   DEFAULT_HANDLE_GROUP_NAME,
 } from 'three-freeform-controls';
+import * as THREE from 'three';
 import randomColor from 'randomcolor';
 import Group from '../primitives/Group';
 import MarkerManager from './markerManager';
@@ -154,6 +155,37 @@ export default class InteractiveMarkerManager {
     }
   }
 
+  static getAlignment(rotation) {
+    const threshold = 10 ** -3;
+    const [x, y, z] = rotation.toArray();
+    for (let i = -4; i <= 4; i++) {
+      const angle = (i * Math.PI) / 2;
+      if (
+        Math.abs(x - angle) < threshold &&
+        Math.abs(y) < threshold &&
+        Math.abs(z) < threshold
+      ) {
+        return 'x';
+      }
+      if (
+        Math.abs(y - angle) < threshold &&
+        Math.abs(x) < threshold &&
+        Math.abs(z) < threshold
+      ) {
+        return 'y';
+      }
+      if (
+        Math.abs(z - angle) < threshold &&
+        Math.abs(y) < threshold &&
+        Math.abs(x) < threshold
+      ) {
+        return 'z';
+      }
+    }
+
+    return null;
+  }
+
   static enableControls(
     object,
     interactionMode,
@@ -161,9 +193,35 @@ export default class InteractiveMarkerManager {
     orientation,
     controlName,
     controlsManager,
-    color,
+    givenColor,
   ) {
     controlsManager.showAll(false);
+
+    const controlsManagerOrientation = new THREE.Quaternion();
+    controlsManager.getWorldQuaternion(controlsManagerOrientation);
+    const controlsManagerRotation = new THREE.Euler().setFromQuaternion(
+      controlsManagerOrientation,
+    );
+    const alignment = InteractiveMarkerManager.getAlignment(
+      controlsManagerRotation,
+    );
+    let alignmentColor;
+    switch (alignment) {
+      case 'x': {
+        alignmentColor = 'red';
+        break;
+      }
+      case 'y': {
+        alignmentColor = 'green';
+        break;
+      }
+      case 'z': {
+        alignmentColor = 'blue';
+        break;
+      }
+      default:
+    }
+    const color = alignmentColor || givenColor;
 
     // currently only ROTATE_AXIS is supported for VIEW_FACING mode
     // this is the most useful one


### PR DESCRIPTION
Interactive marker axes are now colored just like rviz does.

It tries to find an alignment of the controls object with the coordinate axes and colors them accordingly if alignment found, else random color.

![](https://i.imgur.com/bUAk6Dn.png)