### PR TITLE
Create wasmless build for use in CRA

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7862,6 +7862,12 @@
         "rollup-pluginutils": "^2.8.1"
       }
     },
+    "rollup-plugin-ignore-import": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-ignore-import/-/rollup-plugin-ignore-import-1.3.2.tgz",
+      "integrity": "sha512-q7yH2c+PKVfb61+MTXqqyBHIgflikumC7OEB+OfQWNsSmDqE5FLZLeewcBGl1VDmjDjSXuALXsaBjyIsl3oNmQ==",
+      "dev": true
+    },
     "rollup-plugin-replace": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-replace/-/rollup-plugin-replace-2.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "scripts": {
     "build": "rollup -c rollup.config.prod.js",
+    "postbuild": "rollup -c rollup.wasmless.config.prod.js",
     "examples": "webpack-dev-server --config webpack.config.js",
     "lint": "tslint --fix --config tslint.json --project tsconfig.json -t codeFrame 'src/**/*'",
     "prettier": "prettier src/**/* --write",
@@ -59,6 +60,7 @@
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-babel-minify": "^9.1.1",
     "rollup-plugin-commonjs": "^10.1.0",
+    "rollup-plugin-ignore-import": "^1.3.2",
     "rollup-plugin-replace": "^2.2.0",
     "rollup-plugin-typescript2": "^0.25.2",
     "three": "^0.109.0",

--- a/rollup.wasmless.config.prod.js
+++ b/rollup.wasmless.config.prod.js
@@ -1,0 +1,40 @@
+import commonjs from 'rollup-plugin-commonjs';
+import typescript from 'rollup-plugin-typescript2';
+import replace from 'rollup-plugin-replace';
+import minify from 'rollup-plugin-babel-minify';
+import ignoreImport from 'rollup-plugin-ignore-import';
+
+const isExternal = p => !!/^three/.test(p);
+
+export default {
+  input: 'src/index.ts',
+  plugins: [
+    replace({
+      'process.env.NODE_ENV': JSON.stringify('production'),
+    }),
+    typescript({ useTsconfigDeclarationDir: true }),
+    commonjs({ extensions: ['.js', '.ts'] }),
+    ignoreImport({
+      include: ['src/utils/attachPCL.js'],
+      body: 'export default undefined;',
+    }),
+    minify({
+      // TODO: remove this once all files have been translated to `.ts` files
+      comments: false,
+    }),
+  ],
+  treeshake: true,
+  external: p => isExternal(p),
+  output: [
+    {
+      format: 'umd',
+      name: 'amphion',
+      file: 'build/wasmless/amphion.js',
+      sourcemap: true,
+    },
+    {
+      format: 'es',
+      file: 'build/wasmless/amphion.module.js',
+    },
+  ],
+};

--- a/src/utils/attachPCL.js
+++ b/src/utils/attachPCL.js
@@ -1,0 +1,12 @@
+/*
+  This file is in js format intentionally.
+  Using dynamic import requires targeting "esnext",
+  which prevents us from creating a UMD bundle
+ */
+import { PCLDecoder } from './pcl';
+
+if (!window.WebAssembly) {
+  import('pcl-decoder').then(module => {
+    PCLDecoder.attachDecoder(module);
+  });
+}

--- a/src/utils/pcl.ts
+++ b/src/utils/pcl.ts
@@ -1,6 +1,7 @@
 import { BufferGeometry, Color } from 'three';
 import { POINT_FIELD_DATATYPES, POINTCLOUD_COLOR_CHANNELS } from './constants';
 import { assertIsBufferAttribute } from './helpers';
+import './attachPCL';
 
 export const getAccessorForDataType = (
   dataView: DataView,
@@ -222,10 +223,4 @@ export class PCLDecoder {
       return { positions, colors, normals };
     };
   }
-}
-
-if (!window.WebAssembly) {
-  import('pcl-decoder').then(module => {
-    PCLDecoder.attachDecoder(module);
-  });
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "allowJs": true,
     "moduleResolution": "node",
     "target": "es5",
-    "module": "esnext",
+    "module": "es2015",
     "lib": ["es2015", "es2016", "es2017", "dom"],
     "strict": true,
     "sourceMap": true,


### PR DESCRIPTION
Adds build/wasmless/amphion.js and build/wasmless/amphion.module.js files that do not have any imports for wasm. Tested to work with CRA.